### PR TITLE
feat(worker): implement whatsapp worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ apps/worker/state/*
 
 # Misc
 .DS_Store
+dist

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/apps/worker/src/index.js",
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js"
+    "start": "node dist/apps/worker/src/index.js"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "^6.7.7",

--- a/apps/worker/src/incoming.ts
+++ b/apps/worker/src/incoming.ts
@@ -1,8 +1,98 @@
+import type { WAMessage, WASocket } from '@whiskeysockets/baileys';
+import { detectIntent } from './intents';
+import { routeIntent } from './router';
+import type { RouteContext } from './router';
+import { extractText, jidToDisplay, stripMention } from './utils';
+import { TokenBucketRateLimiter } from './rate-limit';
+import { findGroup } from './registry';
+
 export type IncomingContext = {
-  isGroup: boolean;
-  isMentioned: boolean;
+  socket: WASocket;
+  message: WAMessage;
+  botJid: string;
+  limiter: TokenBucketRateLimiter;
 };
 
-export async function handleIncomingMessage(_ctx: IncomingContext) {
-  // TODO: process group messages and ignore DMs unless sending OTP
+function isGroupJid(jid?: string | null): jid is string {
+  return typeof jid === 'string' && jid.endsWith('@g.us');
+}
+
+function isStatusBroadcast(jid?: string | null): boolean {
+  return jid === 'status@broadcast';
+}
+
+function extractMentionedJids(message: WAMessage): string[] {
+  const info = message.message?.extendedTextMessage?.contextInfo;
+  return info?.mentionedJid ?? [];
+}
+
+export async function handleIncomingMessage({ socket, message, botJid, limiter }: IncomingContext) {
+  if (!botJid) {
+    return;
+  }
+
+  const remoteJid = message.key.remoteJid;
+
+  if (!isGroupJid(remoteJid) || isStatusBroadcast(remoteJid)) {
+    return;
+  }
+
+  if (!message.message || message.key.fromMe) {
+    return;
+  }
+
+  const senderJid = message.key.participant ?? remoteJid;
+
+  if (!senderJid || senderJid === botJid) {
+    return;
+  }
+
+  const text = extractText(message);
+
+  if (!text) {
+    return;
+  }
+
+  const mentionedJids = extractMentionedJids(message);
+  const mentionToken = botJid.split('@')[0] ?? botJid;
+  const isMentioned =
+    mentionedJids.includes(botJid) ||
+    text.toLowerCase().includes(`@${mentionToken.toLowerCase()}`);
+
+  if (!isMentioned) {
+    return;
+  }
+
+  const rateKey = `${remoteJid}:${senderJid}`;
+  if (!limiter.isAllowed(rateKey)) {
+    await socket.sendMessage(remoteJid, {
+      text: `@${jidToDisplay(senderJid)} santai dulu ya, coba lagi dalam beberapa detik.`,
+      mentions: [senderJid]
+    });
+    return;
+  }
+
+  const sanitized = stripMention(text, botJid);
+  const intent = detectIntent(sanitized);
+  const groupEntry = findGroup(remoteJid);
+
+  const context: RouteContext = {
+    groupJid: remoteJid,
+    senderJid,
+    message: sanitized,
+    classId: groupEntry?.classId
+  };
+
+  const reply = await routeIntent(intent, context);
+
+  if (!reply) {
+    return;
+  }
+
+  const mentions = reply.mentions?.length ? reply.mentions : [senderJid];
+
+  await socket.sendMessage(remoteJid, {
+    text: reply.text,
+    mentions
+  });
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,100 @@
+import path from 'node:path';
+import makeWASocket, {
+  DisconnectReason,
+  fetchLatestBaileysVersion,
+  useMultiFileAuthState,
+  type WASocket
+} from '@whiskeysockets/baileys';
+import { TokenBucketRateLimiter } from './rate-limit';
+import { handleIncomingMessage } from './incoming';
+
+const RECONNECT_DELAY_MS = 2000;
+
 export async function start() {
-  // TODO: initialize Baileys socket and register event handlers
+  const stateDir = path.resolve(process.cwd(), process.env.WA_STATE_DIR ?? 'apps/worker/state');
+  const { state, saveCreds } = await useMultiFileAuthState(stateDir);
+  const { version } = await fetchLatestBaileysVersion();
+  const limiter = new TokenBucketRateLimiter();
+
+  let socket: WASocket | null = null;
+  let botJid = '';
+  let reconnecting = false;
+
+  const bootSocket = () => {
+    reconnecting = false;
+    socket = makeWASocket({
+      version,
+      auth: state,
+      printQRInTerminal: true,
+      markOnlineOnConnect: false,
+      syncFullHistory: false,
+      browser: ['Unibot', 'Chrome', '1.0.0']
+    });
+
+    socket.ev.on('creds.update', saveCreds);
+
+    socket.ev.on('connection.update', (update) => {
+      const { connection, lastDisconnect, qr } = update;
+
+      if (qr) {
+        console.info('Scan QR code in the terminal to link WhatsApp.');
+      }
+
+      if (connection === 'open') {
+        botJid = socket?.user?.id ?? '';
+        console.info(`WhatsApp connected as ${botJid}`);
+      }
+
+      if (connection === 'close') {
+        const statusCode =
+          (lastDisconnect?.error as any)?.output?.statusCode ?? (lastDisconnect?.error as any)?.statusCode;
+        const shouldReconnect = statusCode !== DisconnectReason.loggedOut;
+
+        if (shouldReconnect && !reconnecting) {
+          reconnecting = true;
+          console.warn('WhatsApp socket closed, attempting to reconnect...');
+          setTimeout(bootSocket, RECONNECT_DELAY_MS);
+        } else if (!shouldReconnect) {
+          console.error('WhatsApp session logged out. Delete auth state to relink.');
+        }
+      }
+    });
+
+    socket.ev.on('messages.upsert', async ({ messages, type }) => {
+      if (type !== 'notify') {
+        return;
+      }
+
+      const message = messages[0];
+
+      if (!message) {
+        return;
+      }
+
+      try {
+        if (!socket) {
+          return;
+        }
+
+        await handleIncomingMessage({
+          socket,
+          message,
+          botJid,
+          limiter
+        });
+      } catch (error) {
+        console.error('Failed to handle incoming message', error);
+      }
+    });
+  };
+
+  bootSocket();
+
+  if (!socket) {
+    throw new Error('Failed to initialize WhatsApp socket');
+  }
+
+  return socket;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/apps/worker/src/intents.ts
+++ b/apps/worker/src/intents.ts
@@ -1,9 +1,43 @@
+import { intentPhrases } from '../../../packages/shared/intent-phrases';
+
+const phrasesDictionary: Record<string, string[]> = intentPhrases as Record<string, string[]>;
+
 export type DetectedIntent = {
   name: string;
   confidence: number;
+  matchedPhrase: string;
 };
 
-export function detectIntent(_message: string): DetectedIntent | null {
-  // TODO: implement rule-based intent detection using shared phrases
-  return null;
+export function detectIntent(message: string): DetectedIntent | null {
+  const normalized = message.toLowerCase().trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  let bestMatch: DetectedIntent | null = null;
+
+  for (const [name, phrases] of Object.entries(phrasesDictionary)) {
+    for (const phrase of phrases) {
+      const candidate = phrase.toLowerCase();
+      const position = normalized.indexOf(candidate);
+
+      if (position === -1) {
+        continue;
+      }
+
+      const coverage = candidate.length / normalized.length;
+      const confidence = Math.min(1, 0.6 + coverage * 0.4);
+
+      if (!bestMatch || confidence > bestMatch.confidence) {
+        bestMatch = {
+          name,
+          confidence,
+          matchedPhrase: phrase
+        };
+      }
+    }
+  }
+
+  return bestMatch;
 }

--- a/apps/worker/src/otp-sender.ts
+++ b/apps/worker/src/otp-sender.ts
@@ -1,3 +1,24 @@
-export async function sendOtpDirectMessage(_jid: string, _code: string) {
-  // TODO: send OTP via direct message using Baileys connection
+import type { WASocket } from '@whiskeysockets/baileys';
+
+function ensureUserJid(identifier: string): string {
+  if (identifier.includes('@')) {
+    return identifier;
+  }
+
+  const sanitized = identifier.replace(/[^0-9]/g, '');
+  return `${sanitized}@s.whatsapp.net`;
+}
+
+export async function sendOtpDirectMessage(sock: WASocket, jidOrPhone: string, code: string) {
+  const targetJid = ensureUserJid(jidOrPhone);
+  const lines = [
+    'Kode OTP Unibot kamu:',
+    `*${code}*`,
+    '',
+    'Kode ini berlaku selama 5 menit. Jangan bagikan kepada siapa pun.'
+  ];
+
+  await sock.sendMessage(targetJid, {
+    text: lines.join('\n')
+  });
 }

--- a/apps/worker/src/router.ts
+++ b/apps/worker/src/router.ts
@@ -1,5 +1,79 @@
 import type { DetectedIntent } from './intents';
+import { callWebInternalApi } from './api';
+import { formatBold, formatList } from '../../../packages/shared/formatting';
+import { jidToDisplay } from './utils';
 
-export async function routeIntent(_intent: DetectedIntent) {
-  // TODO: call internal web API endpoints for business logic
+const bold: (text: string) => string = formatBold as (text: string) => string;
+const list: (items: string[]) => string = formatList as (items: string[]) => string;
+
+export type RouteContext = {
+  groupJid: string;
+  senderJid: string;
+  message: string;
+  classId?: string;
+};
+
+export type RoutedReply = {
+  text: string;
+  mentions?: string[];
+} | null;
+
+function buildFallback(intent: DetectedIntent | null, context: RouteContext): RoutedReply {
+  const mention = `@${jidToDisplay(context.senderJid)}`;
+
+  if (!intent) {
+    return {
+      text: `${mention} maaf, aku belum paham. Ketik *help* untuk lihat perintah yang tersedia.`,
+      mentions: [context.senderJid]
+    };
+  }
+
+  switch (intent.name) {
+    case 'greetings':
+      return {
+        text: `${mention} halo! Ada yang bisa kubantu? Ketik *help* untuk daftar perintah.`,
+        mentions: [context.senderJid]
+      };
+    case 'help':
+      return {
+        text: [
+          `${mention} ${bold('Unibot')} siap bantu dengan:`,
+          list(['Lihat jadwal kelas', 'Cek tugas terbaru', 'Kirim pengumuman internal'])
+        ].join('\n'),
+        mentions: [context.senderJid]
+      };
+    default:
+      return {
+        text: `${mention} catat ya, aku masih belajar untuk perintah "${intent.matchedPhrase}".`,
+        mentions: [context.senderJid]
+      };
+  }
+}
+
+export async function routeIntent(intent: DetectedIntent | null, context: RouteContext): Promise<RoutedReply> {
+  try {
+    const response = await callWebInternalApi({
+      path: '/api/internal/wa/reply',
+      method: 'POST',
+      body: {
+        intent,
+        context
+      }
+    });
+
+    const data = (await response.json().catch(() => null)) as
+      | { message?: string; mentions?: string[] }
+      | null;
+
+    if (data?.message) {
+      return {
+        text: data.message,
+        mentions: data.mentions
+      };
+    }
+  } catch (error) {
+    console.error('Failed to route intent via internal API', error);
+  }
+
+  return buildFallback(intent, context);
 }

--- a/apps/worker/src/utils.ts
+++ b/apps/worker/src/utils.ts
@@ -1,9 +1,66 @@
-export function extractText(_message: unknown): string {
-  // TODO: support Baileys message parsing
+import type { proto, WAMessage } from '@whiskeysockets/baileys';
+
+function unwrapMessage(message?: proto.IMessage | null): proto.IMessage | undefined {
+  if (!message) {
+    return undefined;
+  }
+
+  if (message.ephemeralMessage?.message) {
+    return unwrapMessage(message.ephemeralMessage.message);
+  }
+
+  if (message.viewOnceMessage?.message) {
+    return unwrapMessage(message.viewOnceMessage.message);
+  }
+
+  return message;
+}
+
+export function extractText(message: WAMessage): string {
+  const content = unwrapMessage(message.message);
+
+  if (!content) {
+    return '';
+  }
+
+  if (content.conversation) {
+    return content.conversation;
+  }
+
+  if (content.extendedTextMessage?.text) {
+    return content.extendedTextMessage.text;
+  }
+
+  if (content.imageMessage?.caption) {
+    return content.imageMessage.caption;
+  }
+
+  if (content.videoMessage?.caption) {
+    return content.videoMessage.caption;
+  }
+
+  if (content.buttonsResponseMessage?.selectedButtonId) {
+    return content.buttonsResponseMessage.selectedButtonId;
+  }
+
+  if (content.listResponseMessage?.singleSelectReply?.selectedRowId) {
+    return content.listResponseMessage.singleSelectReply.selectedRowId;
+  }
+
   return '';
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export function stripMention(text: string, botJid: string): string {
-  // TODO: remove bot mention from text reliably
-  return text.replace(new RegExp(botJid, 'gi'), '').trim();
+  const identifier = botJid.split('@')[0] ?? botJid;
+  const mentionPattern = new RegExp(`@${escapeRegExp(identifier)}`, 'gi');
+  const jidPattern = new RegExp(escapeRegExp(botJid), 'gi');
+  return text.replace(mentionPattern, ' ').replace(jidPattern, ' ').replace(/\s+/g, ' ').trim();
+}
+
+export function jidToDisplay(jid: string): string {
+  return jid.split('@')[0] ?? jid;
 }

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
     "module": "ESNext",
     "target": "ES2020",
     "noEmit": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,10 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@unibot/shared/*": ["packages/shared/*"]
+    },
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- initialize the Baileys worker with auth persistence, reconnection handling, and message event wiring
- add mention-aware incoming handling, intent detection, and routing to the web internal API with fallbacks
- provide OTP DM helper plus supporting utilities and configuration updates for building the worker

## Testing
- pnpm --filter worker build

------
https://chatgpt.com/codex/tasks/task_e_68cfed0ef3e4832da1a1a4ee9b8c78af