### PR TITLE
feat(web): build admin dashboard with schedule management

### DIFF
--- a/apps/web/app/admin/_components/schedule-manager.tsx
+++ b/apps/web/app/admin/_components/schedule-manager.tsx
@@ -1,0 +1,542 @@
+'use client';
+
+import { useMemo, useState, type ChangeEvent, type FormEvent } from 'react';
+
+import { WEEKDAYS, WEEKDAY_LABELS, sortByWeekdayAndStartTime } from '../../../lib/weekdays';
+import type { AdminClass, ScheduleRecord } from '../types';
+
+type FormState = {
+  title: string;
+  description: string;
+  room: string;
+  dayOfWeek: (typeof WEEKDAYS)[number];
+  startTime: string;
+  endTime: string;
+};
+
+type StatusState = { type: 'success' | 'error'; message: string } | null;
+
+function createEmptyForm(overrides?: Partial<FormState>): FormState {
+  return {
+    title: '',
+    description: '',
+    room: '',
+    dayOfWeek: WEEKDAYS[0],
+    startTime: '07:00',
+    endTime: '09:00',
+    ...overrides
+  };
+}
+
+export default function ScheduleManager({ classes }: { classes: AdminClass[] }) {
+  const [classState, setClassState] = useState<AdminClass[]>(classes);
+  const [selectedClassId, setSelectedClassId] = useState(() => classes[0]?.id ?? '');
+  const [form, setForm] = useState<FormState>(() => createEmptyForm());
+  const [mode, setMode] = useState<'create' | 'edit'>('create');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [status, setStatus] = useState<StatusState>(null);
+
+  const selectedClass = useMemo(
+    () => classState.find((item) => item.id === selectedClassId),
+    [classState, selectedClassId]
+  );
+
+  const groupedSchedules = useMemo(() => {
+    if (!selectedClass) {
+      return [] as Array<{ day: (typeof WEEKDAYS)[number]; items: ScheduleRecord[] }>;
+    }
+
+    return WEEKDAYS.map((day) => ({
+      day,
+      items: selectedClass.schedules
+        .filter((schedule) => schedule.dayOfWeek === day)
+        .sort((a, b) => a.startTime.localeCompare(b.startTime))
+    })).filter((group) => group.items.length > 0);
+  }, [selectedClass]);
+
+  const canManage = Boolean(selectedClass);
+
+  const handleSelectClass = (event: ChangeEvent<HTMLSelectElement>) => {
+    setSelectedClassId(event.target.value);
+    setMode('create');
+    setEditingId(null);
+    setForm((previous) => createEmptyForm({ dayOfWeek: previous.dayOfWeek }));
+    setStatus(null);
+  };
+
+  const handleEdit = (schedule: ScheduleRecord) => {
+    setMode('edit');
+    setEditingId(schedule.id);
+    setForm({
+      title: schedule.title ?? '',
+      description: schedule.description ?? '',
+      room: schedule.room ?? '',
+      dayOfWeek: schedule.dayOfWeek,
+      startTime: schedule.startTime,
+      endTime: schedule.endTime
+    });
+    setStatus(null);
+  };
+
+  const handleCancelEdit = () => {
+    setMode('create');
+    setEditingId(null);
+    setForm((previous) => createEmptyForm({ dayOfWeek: previous.dayOfWeek }));
+    setStatus(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedClass) {
+      setStatus({ type: 'error', message: 'Pilih kelas terlebih dahulu.' });
+      return;
+    }
+
+    if (mode === 'edit' && !editingId) {
+      setStatus({ type: 'error', message: 'Data jadwal tidak ditemukan.' });
+      return;
+    }
+
+    setSubmitting(true);
+    setStatus(null);
+
+    const payload = {
+      title: form.title.trim(),
+      description: form.description.trim(),
+      room: form.room.trim(),
+      dayOfWeek: form.dayOfWeek,
+      startTime: form.startTime,
+      endTime: form.endTime
+    } as Record<string, unknown>;
+
+    if (!payload.description) {
+      delete payload.description;
+    }
+
+    if (!payload.room) {
+      delete payload.room;
+    }
+
+    try {
+      const response = await fetch(
+        mode === 'create'
+          ? `/api/admin/classes/${selectedClass.id}/schedules`
+          : `/api/admin/schedules/${editingId}`,
+        {
+          method: mode === 'create' ? 'POST' : 'PATCH',
+          headers: {
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify(payload)
+        }
+      );
+
+      const data = (await response.json().catch(() => ({}))) as {
+        schedule?: ScheduleRecord;
+        error?: string;
+      };
+
+      if (!response.ok || !data.schedule) {
+        setStatus({
+          type: 'error',
+          message: data.error ?? 'Gagal menyimpan jadwal. Coba lagi.'
+        });
+        return;
+      }
+
+      const savedSchedule = data.schedule;
+      const targetClassId = savedSchedule.classId;
+
+      setClassState((current) =>
+        current.map((item) => {
+          if (mode === 'create') {
+            if (item.id !== targetClassId) {
+              return item;
+            }
+
+            return {
+              ...item,
+              schedules: [...item.schedules, savedSchedule].sort(sortByWeekdayAndStartTime)
+            };
+          }
+
+          const containsSchedule = item.schedules.some((existing) => existing.id === savedSchedule.id);
+
+          if (!containsSchedule) {
+            return item;
+          }
+
+          return {
+            ...item,
+            schedules: item.schedules
+              .map((existing) => (existing.id === savedSchedule.id ? savedSchedule : existing))
+              .sort(sortByWeekdayAndStartTime)
+          };
+        })
+      );
+
+      setStatus({
+        type: 'success',
+        message: mode === 'create' ? 'Jadwal berhasil ditambahkan.' : 'Jadwal berhasil diperbarui.'
+      });
+
+      if (mode === 'create') {
+        setForm(
+          createEmptyForm({
+            dayOfWeek: form.dayOfWeek,
+            startTime: form.startTime,
+            endTime: form.endTime
+          })
+        );
+      } else {
+        handleCancelEdit();
+      }
+    } catch (error) {
+      console.error(error);
+      setStatus({ type: 'error', message: 'Terjadi kesalahan jaringan. Coba lagi.' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (scheduleId: string) => {
+    const confirmed = window.confirm('Hapus jadwal ini? Pengingat yang terkait juga akan dihentikan.');
+
+    if (!confirmed) {
+      return;
+    }
+
+    if (mode === 'edit' && editingId === scheduleId) {
+      handleCancelEdit();
+    }
+
+    setDeletingId(scheduleId);
+    setStatus(null);
+
+    try {
+      const response = await fetch(`/api/admin/schedules/${scheduleId}`, {
+        method: 'DELETE'
+      });
+
+      const data = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+        classId?: string;
+      };
+
+      if (!response.ok || data.ok !== true) {
+        setStatus({ type: 'error', message: data.error ?? 'Gagal menghapus jadwal.' });
+        return;
+      }
+
+      const targetClassId = data.classId;
+
+      setClassState((current) =>
+        current.map((item) => {
+          if (targetClassId && item.id !== targetClassId) {
+            return item;
+          }
+
+          const filtered = item.schedules.filter((schedule) => schedule.id !== scheduleId);
+
+          if (filtered.length === item.schedules.length) {
+            return item;
+          }
+
+          return {
+            ...item,
+            schedules: filtered
+          };
+        })
+      );
+
+      setStatus({ type: 'success', message: 'Jadwal berhasil dihapus.' });
+    } catch (error) {
+      console.error(error);
+      setStatus({ type: 'error', message: 'Terjadi kesalahan jaringan. Coba lagi.' });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-[0_35px_120px_-70px_rgba(56,189,248,0.55)]">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Pilih Kelas</h3>
+          <p className="text-sm text-slate-300">Ganti kelas untuk melihat jadwal yang terhubung.</p>
+        </div>
+        {classState.length > 0 ? (
+          <select
+            value={selectedClassId}
+            onChange={handleSelectClass}
+            className="w-full rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 md:w-64"
+          >
+            {classState.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.name ?? 'Kelas tanpa nama'}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-3 text-sm text-slate-400">
+            Belum ada kelas terhubung.
+          </div>
+        )}
+      </div>
+
+      {classState.length === 0 ? (
+        <div className="mt-8 rounded-2xl border border-dashed border-white/15 bg-slate-900/40 p-10 text-center text-slate-300">
+          <p className="text-lg font-semibold text-white">Belum ada kelas yang terhubung</p>
+          <p className="mt-3 text-sm">
+            Hubungi tim akademik untuk memastikan data kelas kamu sudah terdaftar dan terhubung dengan grup WhatsApp.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-8 grid gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+          <div className="space-y-5">
+            <div className="flex items-center justify-between">
+              <h4 className="text-base font-semibold text-white">Jadwal Mingguan</h4>
+              <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs text-emerald-200">
+                {selectedClass?.schedules.length ?? 0} slot
+              </span>
+            </div>
+
+            {groupedSchedules.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-white/15 bg-slate-900/40 p-8 text-center text-slate-300">
+                <p className="text-sm">Belum ada jadwal untuk kelas ini. Tambahkan jadwal pertama melalui formulir di samping.</p>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                {groupedSchedules.map((group) => (
+                  <section key={group.day} className="rounded-2xl border border-white/10 bg-slate-900/60 p-5">
+                    <header className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold uppercase tracking-[0.25em] text-emerald-200/80">
+                          {WEEKDAY_LABELS[group.day].short}
+                        </span>
+                        <span className="text-sm text-slate-300">{WEEKDAY_LABELS[group.day].label}</span>
+                      </div>
+                      <span className="rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+                        {group.items.length} kegiatan
+                      </span>
+                    </header>
+
+                    <div className="mt-4 space-y-4">
+                      {group.items.map((schedule) => (
+                        <article
+                          key={schedule.id}
+                          className="rounded-2xl border border-white/10 bg-slate-950/60 p-4 shadow-[0_25px_60px_-45px_rgba(16,185,129,0.65)]"
+                        >
+                          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                            <div className="space-y-2">
+                              <h5 className="text-lg font-semibold text-white">{schedule.title ?? 'Tanpa judul'}</h5>
+                              <div className="flex flex-wrap items-center gap-2 text-xs text-slate-300">
+                                <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 font-medium text-emerald-200">
+                                  {formatTimeRange(schedule.startTime, schedule.endTime)}
+                                </span>
+                                {schedule.room && (
+                                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-300">
+                                    Ruang {schedule.room}
+                                  </span>
+                                )}
+                              </div>
+                              {schedule.description && (
+                                <p className="text-sm text-slate-300">{schedule.description}</p>
+                              )}
+                            </div>
+
+                            <div className="flex gap-2 text-xs font-semibold">
+                              <button
+                                type="button"
+                                onClick={() => handleEdit(schedule)}
+                                className="rounded-full border border-white/10 px-4 py-2 text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100"
+                              >
+                                Ubah
+                              </button>
+                              <button
+                                type="button"
+                                disabled={deletingId === schedule.id}
+                                onClick={() => handleDelete(schedule.id)}
+                                className="rounded-full border border-rose-400/30 px-4 py-2 text-rose-300 transition hover:border-rose-300 hover:text-rose-200 disabled:cursor-not-allowed disabled:opacity-60"
+                              >
+                                {deletingId === schedule.id ? 'Menghapus…' : 'Hapus'}
+                              </button>
+                            </div>
+                          </div>
+                        </article>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-5 rounded-2xl border border-white/10 bg-slate-900/50 p-6 shadow-[0_25px_80px_-60px_rgba(6,182,212,0.55)]"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-emerald-300/80">
+                  {mode === 'create' ? 'Tambah Jadwal' : 'Ubah Jadwal'}
+                </p>
+                <h4 className="mt-2 text-lg font-semibold text-white">
+                  {mode === 'create' ? 'Slot Baru' : 'Perbarui Slot'}
+                </h4>
+              </div>
+              {mode === 'edit' && (
+                <button
+                  type="button"
+                  onClick={handleCancelEdit}
+                  className="rounded-full border border-white/15 px-4 py-2 text-xs font-semibold text-slate-200 transition hover:border-emerald-300 hover:text-emerald-100"
+                >
+                  Batal
+                </button>
+              )}
+            </div>
+
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200/80" htmlFor="schedule-title">
+                  Judul
+                </label>
+                <input
+                  id="schedule-title"
+                  type="text"
+                  required
+                  disabled={!canManage || submitting}
+                  value={form.title}
+                  onChange={(event) => setForm((previous) => ({ ...previous, title: event.target.value }))}
+                  placeholder="Contoh: Matematika Diskrit"
+                  className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200/80" htmlFor="schedule-day">
+                    Hari
+                  </label>
+                  <select
+                    id="schedule-day"
+                    value={form.dayOfWeek}
+                    disabled={!canManage || submitting}
+                    onChange={(event) =>
+                      setForm((previous) => ({
+                        ...previous,
+                        dayOfWeek: event.target.value as FormState['dayOfWeek']
+                      }))
+                    }
+                    className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {WEEKDAYS.map((day) => (
+                      <option key={day} value={day}>
+                        {WEEKDAY_LABELS[day].label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200/80" htmlFor="schedule-room">
+                    Ruangan (opsional)
+                  </label>
+                  <input
+                    id="schedule-room"
+                    type="text"
+                    disabled={!canManage || submitting}
+                    value={form.room}
+                    onChange={(event) => setForm((previous) => ({ ...previous, room: event.target.value }))}
+                    placeholder="Contoh: R.301"
+                    className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-60"
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200/80" htmlFor="schedule-start">
+                    Jam Mulai
+                  </label>
+                  <input
+                    id="schedule-start"
+                    type="time"
+                    required
+                    step={300}
+                    disabled={!canManage || submitting}
+                    value={form.startTime}
+                    onChange={(event) => setForm((previous) => ({ ...previous, startTime: event.target.value }))}
+                    className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-60"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200/80" htmlFor="schedule-end">
+                    Jam Selesai
+                  </label>
+                  <input
+                    id="schedule-end"
+                    type="time"
+                    required
+                    step={300}
+                    disabled={!canManage || submitting}
+                    value={form.endTime}
+                    onChange={(event) => setForm((previous) => ({ ...previous, endTime: event.target.value }))}
+                    className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-60"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200/80" htmlFor="schedule-notes">
+                  Catatan (opsional)
+                </label>
+                <textarea
+                  id="schedule-notes"
+                  rows={3}
+                  disabled={!canManage || submitting}
+                  value={form.description}
+                  onChange={(event) => setForm((previous) => ({ ...previous, description: event.target.value }))}
+                  placeholder="Materi, dosen pengampu, atau pengingat tambahan."
+                  className="w-full rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 outline-none transition focus:border-emerald-300 focus:ring-2 focus:ring-emerald-400/40 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+            </div>
+
+            {status && (
+              <p
+                className={`text-sm ${
+                  status.type === 'success' ? 'text-emerald-300' : 'text-rose-400'
+                }`}
+              >
+                {status.message}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={!canManage || submitting}
+              className="w-full rounded-2xl bg-emerald-400 px-4 py-3 text-sm font-semibold text-slate-900 transition hover:-translate-y-[2px] hover:bg-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting
+                ? mode === 'create'
+                  ? 'Menyimpan Jadwal…'
+                  : 'Memperbarui…'
+                : mode === 'create'
+                  ? 'Tambahkan Jadwal'
+                  : 'Simpan Perubahan'}
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatTimeRange(start: string, end: string) {
+  return `${start.slice(0, 5)} - ${end.slice(0, 5)}`;
+}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -1,5 +1,14 @@
 import type { ReactNode } from 'react';
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
-  return <section className="min-h-screen bg-white">{children}</section>;
+  return (
+    <section className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-12rem] h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-emerald-500/20 blur-[160px]" />
+        <div className="absolute right-[-18%] top-[22rem] hidden h-80 w-80 rounded-full bg-cyan-500/20 blur-[140px] lg:block" />
+        <div className="absolute left-[-10%] bottom-[-8rem] h-72 w-72 rounded-full bg-purple-500/15 blur-[140px]" />
+      </div>
+      <div className="relative">{children}</div>
+    </section>
+  );
 }

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,61 +1,156 @@
 import Link from 'next/link';
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 
+import { hasActiveSession } from '../../lib/auth';
 import { getSession } from '../../lib/session';
+import { WEEKDAY_LABELS } from '../../lib/weekdays';
+import type { AdminClass, AdminDashboardResponse } from './types';
+import ScheduleManager from './_components/schedule-manager';
 
 export default async function AdminDashboardPage() {
   const session = await getSession();
 
+  if (!hasActiveSession(session) || !session.userId) {
+    redirect('/admin/login');
+  }
+
+  const data = await loadDashboardData();
+  const adminClasses: AdminClass[] = data.classes;
+
+  const classCountLabel = data.stats.classCount.toLocaleString('id-ID');
+  const totalSchedulesLabel = data.stats.totalSchedules.toLocaleString('id-ID');
+  const upcoming = data.upcoming;
+
+  const upcomingTitle = upcoming ? upcoming.schedule.title ?? 'Tanpa judul' : 'Belum ada jadwal';
+  const upcomingMeta = upcoming
+    ? `${upcoming.className} · ${WEEKDAY_LABELS[upcoming.schedule.dayOfWeek].label}, ${formatTimeRange(
+        upcoming.schedule.startTime,
+        upcoming.schedule.endTime
+      )}`
+    : 'Tambahkan jadwal untuk menyiapkan pengingat otomatis.';
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-10 px-6 py-12 text-slate-900">
-      <header className="space-y-2">
-        <p className="text-sm font-medium text-emerald-600">Hai, Ketua Kelas 👋</p>
-        <h1 className="text-3xl font-semibold">Dashboard Unibot</h1>
-        <p className="max-w-2xl text-sm text-slate-600">
-          Kelola jadwal, tugas, dan koneksi grup WhatsApp kamu. Kami akan segera menambahkan aksi lanjutan — sementara ini,
-          kamu bisa mengecek data yang sudah tersinkron dan mempersiapkan reminder.
-        </p>
-        <p className="text-xs text-slate-500">
-          Masuk sebagai: <span className="font-mono">{session.phoneNumber ?? '—'}</span>
-        </p>
+    <main className="relative mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 py-16 md:px-12">
+      <header className="space-y-8">
+        <div className="space-y-5">
+          <p className="text-xs uppercase tracking-[0.45em] text-emerald-300/80">Dashboard</p>
+          <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+            <div className="max-w-2xl space-y-4">
+              <h1 className="text-3xl font-semibold text-white md:text-4xl">Hai, Ketua Kelas 👋</h1>
+              <p className="text-sm text-slate-300">
+                Kelola jadwal mingguan kelas kamu, siapkan pengingat otomatis, dan pantau integrasi dengan grup WhatsApp.
+                Semua aksi akan segera terhubung langsung dengan Unibot di percakapan kampus.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <Link
+                  href="https://github.com/imyourdream/unibot"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold text-emerald-200 transition hover:border-emerald-300 hover:text-emerald-100"
+                >
+                  GitHub & Dokumentasi ↗
+                </Link>
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-5 text-xs text-slate-300 shadow-[0_25px_70px_-45px_rgba(56,189,248,0.55)]">
+              <p className="uppercase tracking-[0.3em] text-emerald-300/70">Masuk sebagai</p>
+              <p className="mt-3 font-mono text-sm text-white">{session.phoneNumber ?? '—'}</p>
+            </div>
+          </div>
+        </div>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          <StatCard
+            label="Kelas Aktif"
+            value={classCountLabel}
+            description="Jumlah kelas yang terhubung dengan akun kamu."
+          />
+          <StatCard
+            label="Slot Jadwal"
+            value={totalSchedulesLabel}
+            description="Total jadwal mingguan yang akan diingatkan oleh Unibot."
+          />
+          <StatCard label="Jadwal Terdekat" value={upcomingTitle} description={upcomingMeta} variant="accent" />
+        </section>
       </header>
 
-      <section className="grid gap-6 md:grid-cols-2">
-        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold">Jadwal Kuliah</h2>
-          <p className="mt-2 text-sm text-slate-600">
-            Tambahkan atau sesuaikan jadwal mingguan kelas. Unibot akan mengirim reminder sesuai slot waktu yang kamu atur.
+      <section className="space-y-6">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Kelola Jadwal Kelas</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            Tambahkan, ubah, atau hapus jadwal kuliah. Unibot akan mengirim pengingat sesuai jam yang kamu atur di sini.
           </p>
-          <div className="mt-4 text-sm text-emerald-600">Segera hadir.</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold">Tugas &amp; Deadline</h2>
-          <p className="mt-2 text-sm text-slate-600">
-            Kelola daftar tugas dan tenggat penting, lalu aktifkan pengingat otomatis ke grup WhatsApp kelas.
-          </p>
-          <div className="mt-4 text-sm text-emerald-600">Segera hadir.</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold">Koneksi Grup</h2>
-          <p className="mt-2 text-sm text-slate-600">
-            Pastikan setiap kelas sudah terhubung dengan grup WhatsApp melalui perintah <span className="font-mono">@unibot register</span>.
-          </p>
-          <div className="mt-4 text-sm text-emerald-600">Log integrasi akan muncul di sini.</div>
-        </article>
-        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold">Resource Lain</h2>
-          <p className="mt-2 text-sm text-slate-600">
-            Baca dokumentasi arsitektur dan kontribusi ke proyek open-source Unibot.
-          </p>
-          <Link
-            href="https://github.com/imyourdream/unibot"
-            target="_blank"
-            rel="noreferrer"
-            className="mt-4 inline-flex text-sm font-semibold text-emerald-600 hover:text-emerald-500"
-          >
-            Lihat GitHub ↗
-          </Link>
-        </article>
+        </div>
+
+        <ScheduleManager classes={adminClasses} />
       </section>
     </main>
+  );
+}
+function formatTimeRange(start: string, end: string) {
+  return `${formatTimeLabel(start)} - ${formatTimeLabel(end)}`;
+}
+
+function formatTimeLabel(value: string) {
+  return value?.slice(0, 5) ?? value;
+}
+
+async function loadDashboardData(): Promise<AdminDashboardResponse> {
+  const headerList = headers();
+  const protocol =
+    headerList.get('x-forwarded-proto') ?? (process.env.NODE_ENV === 'development' ? 'http' : 'https');
+  const host = headerList.get('host');
+
+  if (!host) {
+    throw new Error('Host header is missing');
+  }
+
+  const cookieStore = cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join('; ');
+
+  const response = await fetch(`${protocol}://${host}/api/admin/dashboard`, {
+    headers: {
+      ...(cookieHeader ? { cookie: cookieHeader } : {}),
+      accept: 'application/json'
+    },
+    cache: 'no-store'
+  });
+
+  if (response.status === 401) {
+    redirect('/admin/login');
+  }
+
+  if (!response.ok) {
+    throw new Error('Gagal memuat data dashboard.');
+  }
+
+  return (await response.json()) as AdminDashboardResponse;
+}
+
+function StatCard({
+  label,
+  value,
+  description,
+  variant = 'default'
+}: {
+  label: string;
+  value: string;
+  description: string;
+  variant?: 'default' | 'accent';
+}) {
+  return (
+    <article
+      className={`rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_80px_-45px_rgba(6,182,212,0.45)] ${
+        variant === 'accent' ? 'bg-gradient-to-br from-emerald-400/20 via-emerald-500/10 to-transparent' : ''
+      }`}
+    >
+      <p className="text-xs uppercase tracking-[0.35em] text-emerald-300/70">{label}</p>
+      <h3 className="mt-3 text-2xl font-semibold text-white">{value}</h3>
+      <p className="mt-2 text-sm text-slate-300">{description}</p>
+    </article>
   );
 }

--- a/apps/web/app/admin/types.ts
+++ b/apps/web/app/admin/types.ts
@@ -1,0 +1,36 @@
+import type { Weekday } from '../../lib/weekdays';
+
+export type ScheduleRecord = {
+  id: string;
+  classId: string;
+  title: string | null;
+  description: string | null;
+  room: string | null;
+  dayOfWeek: Weekday;
+  startTime: string;
+  endTime: string;
+};
+
+export type AdminClass = {
+  id: string;
+  name: string | null;
+  description: string | null;
+  schedules: ScheduleRecord[];
+};
+
+export type DashboardStats = {
+  classCount: number;
+  totalSchedules: number;
+};
+
+export type UpcomingSchedule = {
+  schedule: ScheduleRecord;
+  className: string;
+  startDateIso: string;
+};
+
+export type AdminDashboardResponse = {
+  classes: AdminClass[];
+  stats: DashboardStats;
+  upcoming: UpcomingSchedule | null;
+};

--- a/apps/web/app/api/admin/classes/[classId]/schedules/route.ts
+++ b/apps/web/app/api/admin/classes/[classId]/schedules/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import prisma from '../../../../../../lib/prisma';
+import { getSession } from '../../../../../../lib/session';
+import { hasActiveSession } from '../../../../../../lib/auth';
+import { isClassAdmin } from '../../../../../../lib/admin';
+import { scheduleInputSchema } from '../../../../../../lib/validation/schedule';
+import { sortByWeekdayAndStartTime } from '../../../../../../lib/weekdays';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { classId: string } }
+) {
+  const session = await getSession();
+  const userId = session.userId;
+  const classId = params.classId;
+
+  if (!hasActiveSession(session) || !userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!classId) {
+    return NextResponse.json({ error: 'ID kelas tidak valid' }, { status: 400 });
+  }
+
+  const allowed = await isClassAdmin(userId, classId);
+
+  if (!allowed) {
+    return NextResponse.json({ error: 'Akses ke kelas ini ditolak' }, { status: 403 });
+  }
+
+  const schedules = await prisma.schedule.findMany({
+    where: { classId },
+    select: {
+      id: true,
+      classId: true,
+      title: true,
+      description: true,
+      room: true,
+      dayOfWeek: true,
+      startTime: true,
+      endTime: true
+    }
+  });
+
+  return NextResponse.json({
+    schedules: schedules.map(serializeSchedule).sort(sortByWeekdayAndStartTime)
+  });
+}
+
+export async function POST(request: NextRequest, { params }: { params: { classId: string } }) {
+  const session = await getSession();
+  const userId = session.userId;
+  const classId = params.classId;
+
+  if (!hasActiveSession(session) || !userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!classId) {
+    return NextResponse.json({ error: 'ID kelas tidak valid' }, { status: 400 });
+  }
+
+  const allowed = await isClassAdmin(userId, classId);
+
+  if (!allowed) {
+    return NextResponse.json({ error: 'Akses ke kelas ini ditolak' }, { status: 403 });
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Body tidak valid' }, { status: 400 });
+  }
+
+  const parsed = scheduleInputSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? 'Permintaan tidak valid' }, { status: 400 });
+  }
+
+  const description = parsed.data.description?.trim();
+  const room = parsed.data.room?.trim();
+
+  const schedule = await prisma.schedule.create({
+    data: {
+      classId,
+      title: parsed.data.title,
+      description: description && description.length > 0 ? description : null,
+      room: room && room.length > 0 ? room : null,
+      dayOfWeek: parsed.data.dayOfWeek,
+      startTime: parsed.data.startTime,
+      endTime: parsed.data.endTime
+    },
+    select: {
+      id: true,
+      classId: true,
+      title: true,
+      description: true,
+      room: true,
+      dayOfWeek: true,
+      startTime: true,
+      endTime: true
+    }
+  });
+
+  return NextResponse.json({ schedule: serializeSchedule(schedule) }, { status: 201 });
+}
+
+function serializeSchedule(schedule: {
+  id: string;
+  classId: string;
+  title: string | null;
+  description: string | null;
+  room: string | null;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+}) {
+  return {
+    id: schedule.id,
+    classId: schedule.classId,
+    title: schedule.title,
+    description: schedule.description,
+    room: schedule.room,
+    dayOfWeek: schedule.dayOfWeek,
+    startTime: schedule.startTime,
+    endTime: schedule.endTime
+  };
+}

--- a/apps/web/app/api/admin/schedules/[scheduleId]/route.ts
+++ b/apps/web/app/api/admin/schedules/[scheduleId]/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import prisma from '../../../../../../lib/prisma';
+import { getSession } from '../../../../../../lib/session';
+import { hasActiveSession } from '../../../../../../lib/auth';
+import { loadScheduleForAdmin } from '../../../../../../lib/admin';
+import { scheduleInputSchema } from '../../../../../../lib/validation/schedule';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { scheduleId: string } }
+) {
+  const session = await getSession();
+  const userId = session.userId;
+  const scheduleId = params.scheduleId;
+
+  if (!hasActiveSession(session) || !userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!scheduleId) {
+    return NextResponse.json({ error: 'ID jadwal tidak valid' }, { status: 400 });
+  }
+
+  const { schedule: existingSchedule, allowed, exists } = await loadScheduleForAdmin(userId, scheduleId);
+
+  if (!exists) {
+    return NextResponse.json({ error: 'Jadwal tidak ditemukan' }, { status: 404 });
+  }
+
+  if (!allowed || !existingSchedule) {
+    return NextResponse.json({ error: 'Akses ke jadwal ini ditolak' }, { status: 403 });
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Body tidak valid' }, { status: 400 });
+  }
+
+  const parsed = scheduleInputSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? 'Permintaan tidak valid' }, { status: 400 });
+  }
+
+  const description = parsed.data.description?.trim();
+  const room = parsed.data.room?.trim();
+
+  const updated = await prisma.schedule.update({
+    where: { id: scheduleId },
+    data: {
+      title: parsed.data.title,
+      description: description && description.length > 0 ? description : null,
+      room: room && room.length > 0 ? room : null,
+      dayOfWeek: parsed.data.dayOfWeek,
+      startTime: parsed.data.startTime,
+      endTime: parsed.data.endTime
+    },
+    select: {
+      id: true,
+      classId: true,
+      title: true,
+      description: true,
+      room: true,
+      dayOfWeek: true,
+      startTime: true,
+      endTime: true
+    }
+  });
+
+  return NextResponse.json({ schedule: serializeSchedule(updated) });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { scheduleId: string } }
+) {
+  const session = await getSession();
+  const userId = session.userId;
+  const scheduleId = params.scheduleId;
+
+  if (!hasActiveSession(session) || !userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!scheduleId) {
+    return NextResponse.json({ error: 'ID jadwal tidak valid' }, { status: 400 });
+  }
+
+  const { schedule: existingSchedule, allowed, exists } = await loadScheduleForAdmin(userId, scheduleId);
+
+  if (!exists) {
+    return NextResponse.json({ error: 'Jadwal tidak ditemukan' }, { status: 404 });
+  }
+
+  if (!allowed || !existingSchedule) {
+    return NextResponse.json({ error: 'Akses ke jadwal ini ditolak' }, { status: 403 });
+  }
+
+  await prisma.schedule.delete({ where: { id: scheduleId } });
+
+  return NextResponse.json({ ok: true, classId: existingSchedule.classId });
+}
+
+function serializeSchedule(schedule: {
+  id: string;
+  classId: string;
+  title: string | null;
+  description: string | null;
+  room: string | null;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+}) {
+  return {
+    id: schedule.id,
+    classId: schedule.classId,
+    title: schedule.title,
+    description: schedule.description,
+    room: schedule.room,
+    dayOfWeek: schedule.dayOfWeek,
+    startTime: schedule.startTime,
+    endTime: schedule.endTime
+  };
+}

--- a/apps/web/lib/admin.ts
+++ b/apps/web/lib/admin.ts
@@ -1,0 +1,50 @@
+import prisma from './prisma';
+
+export async function isClassAdmin(userId: string, classId: string): Promise<boolean> {
+  if (!userId || !classId) {
+    return false;
+  }
+
+  const membership = await prisma.classMember.findFirst({
+    where: {
+      userId,
+      classId,
+      role: 'admin'
+    },
+    select: { id: true }
+  });
+
+  return Boolean(membership);
+}
+
+export async function loadScheduleForAdmin(userId: string, scheduleId: string) {
+  const schedule = await prisma.schedule.findUnique({
+    where: { id: scheduleId },
+    select: {
+      id: true,
+      classId: true,
+      title: true,
+      description: true,
+      room: true,
+      dayOfWeek: true,
+      startTime: true,
+      endTime: true
+    }
+  });
+
+  if (!schedule) {
+    return {
+      exists: false,
+      allowed: false,
+      schedule: null
+    } as const;
+  }
+
+  const allowed = await isClassAdmin(userId, schedule.classId);
+
+  return {
+    exists: true,
+    allowed,
+    schedule: allowed ? schedule : null
+  } as const;
+}

--- a/apps/web/lib/validation/schedule.ts
+++ b/apps/web/lib/validation/schedule.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+import { WEEKDAYS } from '../weekdays';
+
+const timeSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Waktu harus dalam format 24 jam (HH:MM)');
+
+export const scheduleInputSchema = z
+  .object({
+    title: z.string().min(1, 'Judul wajib diisi').max(120, 'Judul terlalu panjang').trim(),
+    description: z.string().max(280, 'Deskripsi maksimal 280 karakter').optional(),
+    room: z.string().max(64, 'Nama ruangan maksimal 64 karakter').optional(),
+    dayOfWeek: z.enum(WEEKDAYS),
+    startTime: timeSchema,
+    endTime: timeSchema
+  })
+  .refine((data) => data.endTime > data.startTime, {
+    path: ['endTime'],
+    message: 'Jam selesai harus setelah jam mulai'
+  });
+
+export type ScheduleInput = z.infer<typeof scheduleInputSchema>;

--- a/apps/web/lib/weekdays.ts
+++ b/apps/web/lib/weekdays.ts
@@ -1,0 +1,54 @@
+export const WEEKDAYS = [
+  'MONDAY',
+  'TUESDAY',
+  'WEDNESDAY',
+  'THURSDAY',
+  'FRIDAY',
+  'SATURDAY',
+  'SUNDAY'
+] as const;
+
+export type Weekday = (typeof WEEKDAYS)[number];
+
+export const WEEKDAY_LABELS: Record<Weekday, { short: string; label: string }> = {
+  MONDAY: { short: 'Sen', label: 'Senin' },
+  TUESDAY: { short: 'Sel', label: 'Selasa' },
+  WEDNESDAY: { short: 'Rab', label: 'Rabu' },
+  THURSDAY: { short: 'Kam', label: 'Kamis' },
+  FRIDAY: { short: 'Jum', label: 'Jumat' },
+  SATURDAY: { short: 'Sab', label: 'Sabtu' },
+  SUNDAY: { short: 'Min', label: 'Minggu' }
+};
+
+export const WEEKDAY_ORDER: Record<Weekday, number> = {
+  MONDAY: 0,
+  TUESDAY: 1,
+  WEDNESDAY: 2,
+  THURSDAY: 3,
+  FRIDAY: 4,
+  SATURDAY: 5,
+  SUNDAY: 6
+};
+
+export const WEEKDAY_TO_DAYJS_INDEX: Record<Weekday, number> = {
+  MONDAY: 1,
+  TUESDAY: 2,
+  WEDNESDAY: 3,
+  THURSDAY: 4,
+  FRIDAY: 5,
+  SATURDAY: 6,
+  SUNDAY: 0
+};
+
+export function sortByWeekdayAndStartTime<T extends { dayOfWeek: Weekday; startTime: string }>(
+  a: T,
+  b: T
+) {
+  const dayDifference = WEEKDAY_ORDER[a.dayOfWeek] - WEEKDAY_ORDER[b.dayOfWeek];
+
+  if (dayDifference !== 0) {
+    return dayDifference;
+  }
+
+  return a.startTime.localeCompare(b.startTime);
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { unsealData } from 'iron-session/edge';
 
-import { sessionOptions, type SessionData } from '../lib/session';
+import { sessionOptions, type SessionData } from './lib/session';
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
## Summary
- restyle the admin layout to match the dark marketing theme, show dashboard stats, and guard unauthenticated users
- add a schedule manager client component with class selection, CRUD actions, and grouped weekly views
- expose schedule CRUD APIs with validation and admin access helpers while moving the auth middleware to the app root
- serve admin dashboard data via a dedicated API endpoint and consume it from the page instead of querying Prisma directly

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68d038514b20832da8eb0d5d56b81301